### PR TITLE
Disable GUI by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,5 @@ Below, you can find the steps to execute the program:
    python main.py
    ```
  
-10. To change the config of the machines and task types, open ```config.json``` and add new task types in the same format present and increase or decrease the amount of each machine present as well as add new machine types etc also in the format present. Once the desired changes have been made, save the changed files and run python main.py to see the results in the window.window 
+10. To change the config of the machines and task types, open ```config.json``` and add new task types in the same format present and increase or decrease the amount of each machine present as well as add new machine types etc also in the format present. Once the desired changes have been made, save the changed files and run python main.py to see the results in the window.
+11. If you want to run the simulator without the graphical interface (for example, when deploying it as a backend service), set the `"gui"` option in `config.json` to `0`.

--- a/V1/config.json
+++ b/V1/config.json
@@ -12,7 +12,7 @@
             "path_to_output": "./output",
             "path_to_workload": "./workload",
             "verbosity": 3,
-            "gui": 1
+            "gui": 0
         }
     ],
     "task_types": [


### PR DESCRIPTION
## Summary
- turn off GUI in default `config.json`
- mention in README how to run headless

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bebcd8bdc83249adaa9dcc9cdd29a